### PR TITLE
minor bugfixes

### DIFF
--- a/public_html/js/jquery.throwable.js
+++ b/public_html/js/jquery.throwable.js
@@ -711,7 +711,7 @@ function $A(e){if(!e)return[];if(e.toArray)return e.toArray();var t=e.length||0,
 
                         if (this.stage.Y !== offset.top) {
                             this.delta.Y = (offset.top - this.stage.Y) * 50;
-                            this.stage.Y = ofsset.top;
+                            this.stage.Y = offset.top;
                             changed = true;
                         }
 


### PR DESCRIPTION
ofsset typo causes exception when screen size changed in-animation

`this` scope but causes exception when collision object list (`this.elements`) is resized from a $(object).remove() call
